### PR TITLE
fix: Sidebar anchor takes 100% of available width

### DIFF
--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -56,6 +56,7 @@
     text-decoration: none;
     color: inherit;
     display: block;
+    width: 100%;
 }
 
 .sidebar-nav .list li:hover {


### PR DESCRIPTION
Now the hole li element is clickable for navigating through the application